### PR TITLE
Add PyPy3.6 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 python:
   - 3.6
   - 3.7
+  - pypy3.6-7.1.1
 matrix:
   include:
     - name: flake8


### PR DESCRIPTION
I've checked with http head and 'pypy3.6' is not supported, but 'pypy3'
and 'pypy3.6-7.1.1' are (and point to the same archive at the moment).