### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
   - pypy3.6-7.1.1
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ python:
   - 3.7
   - 3.8
   - 3.9
-  - 3.9-dev
   - pypy3
 jobs:
-  allow_failures:
-    - python: 3.9  # travis doesn't have it yet
   include:
     - name: flake8
       install: pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - 3.9
-  - pypy3.6-7.1.1
+  - 3.9-dev
+  - pypy3
 matrix:
   include:
     - name: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
   - 3.9-dev
   - pypy3
-matrix:
+jobs:
+  allow_failures:
+    - python: 3.9  # travis doesn't have it yet
   include:
     - name: flake8
       install: pip install tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,10 @@
 Changelog
 =========
 
-0.15.2 (unreleased)
+0.16.0 (unreleased)
 -------------------
+
+- Add support for Python 3.9.
 
 - Python 3.10 support: sort 3.10 after 3.9, quote "3.10" when
   updating YAML files so it doesn't get treated as a floating point

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
+    - PYTHON: "C:\\Python39"
 
 init:
   - "echo %PYTHON%"

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/src/check_python_versions/__init__.py
+++ b/src/check_python_versions/__init__.py
@@ -12,4 +12,4 @@ Makes sure the set of supported Python versions is consistent between
 """
 
 __author__ = 'Marius Gedminas <marius@gedmin.as>'
-__version__ = '0.15.2.dev0'
+__version__ = '0.16.0.dev0'

--- a/src/check_python_versions/versions.py
+++ b/src/check_python_versions/versions.py
@@ -11,7 +11,7 @@ from typing import Collection, List, NamedTuple, Optional, Set, Union
 
 MAX_PYTHON_1_VERSION = 6  # i.e. 1.6
 MAX_PYTHON_2_VERSION = 7  # i.e. 2.7
-CURRENT_PYTHON_3_VERSION = 8  # i.e. 3.8
+CURRENT_PYTHON_3_VERSION = 9  # i.e. 3.9
 
 MAX_MINOR_FOR_MAJOR = {
     1: MAX_PYTHON_1_VERSION,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py36,py37,py38,mypy,isort,coverage
+envlist = py36,py37,py38,py39,flake8,mypy,isort,coverage
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Travis CI status (eventually, hopefully): https://travis-ci.org/github/mgedmin/check-python-versions/builds/733030316

Travis seems very overloaded lately.  I think they want people to migrate to other CI services.