### PR TITLE
Replace envlist with env_list in tox

### DIFF
--- a/src/check_python_versions/sources/tox.py
+++ b/src/check_python_versions/sources/tox.py
@@ -10,7 +10,7 @@ packages, and run the test commands you specified.
 The list of supported Python versions is extracted from ::
 
     [tox]
-    envlist = py27,py36,py37,py38
+    env_list = py27,py36,py37,py38
 
 """
 
@@ -35,7 +35,7 @@ def get_tox_ini_python_versions(
     try:
         with open_file(filename) as fp:
             conf.read_file(fp)
-        envlist = conf.get('tox', 'envlist')
+        envlist = conf.get('tox', 'env_list')
     except configparser.Error:
         return []
     return sorted({
@@ -124,7 +124,7 @@ def update_tox_ini_python_versions(
         conf = configparser.ConfigParser()
         try:
             conf.read_file(fp)
-            envlist = conf.get('tox', 'envlist')
+            envlist = conf.get('tox', 'env_list')
         except configparser.Error as error:
             warn(f"Could not parse {fp.name}: {error}")
             return orig_lines
@@ -132,7 +132,7 @@ def update_tox_ini_python_versions(
     new_envlist = update_tox_envlist(envlist, new_versions)
 
     new_lines = update_ini_setting(
-        orig_lines, 'tox', 'envlist', new_envlist, filename=fp.name,
+        orig_lines, 'tox', 'env_list', new_envlist, filename=fp.name,
     )
     return new_lines
 

--- a/tests/parsers/test_ini.py
+++ b/tests/parsers/test_ini.py
@@ -6,14 +6,14 @@ from check_python_versions.parsers.ini import update_ini_setting
 def test_update_ini_setting():
     source_lines = textwrap.dedent("""\
         [tox]
-        envlist = py26,py27
+        env_list = py26,py27
         usedevelop = true
     """).splitlines(True)
-    result = update_ini_setting(source_lines, 'tox', 'envlist', 'py36,py37',
+    result = update_ini_setting(source_lines, 'tox', 'env_list', 'py36,py37',
                                 filename='tox.ini')
     assert "".join(result) == textwrap.dedent("""\
         [tox]
-        envlist = py36,py37
+        env_list = py36,py37
         usedevelop = true
     """)
 
@@ -21,14 +21,14 @@ def test_update_ini_setting():
 def test_update_ini_setting_nospaces():
     source_lines = textwrap.dedent("""\
         [tox]
-        envlist=py26,py27
+        env_list=py26,py27
         usedevelop=true
     """).splitlines(True)
-    result = update_ini_setting(source_lines, 'tox', 'envlist', 'py36,py37',
+    result = update_ini_setting(source_lines, 'tox', 'env_list', 'py36,py37',
                                 filename='tox.ini')
     assert "".join(result) == textwrap.dedent("""\
         [tox]
-        envlist=py36,py37
+        env_list=py36,py37
         usedevelop=true
     """)
 
@@ -36,14 +36,14 @@ def test_update_ini_setting_nospaces():
 def test_update_ini_setting_from_empty():
     source_lines = textwrap.dedent("""\
         [tox]
-        envlist =
+        env_list =
         usedevelop = true
     """).splitlines(True)
-    result = update_ini_setting(source_lines, 'tox', 'envlist', 'py36,py37',
+    result = update_ini_setting(source_lines, 'tox', 'env_list', 'py36,py37',
                                 filename='tox.ini')
     assert "".join(result) == textwrap.dedent("""\
         [tox]
-        envlist = py36,py37
+        env_list = py36,py37
         usedevelop = true
     """)
 
@@ -51,16 +51,16 @@ def test_update_ini_setting_from_empty():
 def test_update_ini_setting_multiline():
     source_lines = textwrap.dedent("""\
         [tox]
-        envlist =
+        env_list =
             py26,
             py27
         usedevelop = true
     """).splitlines(True)
-    result = update_ini_setting(source_lines, 'tox', 'envlist', 'py36,\npy37',
+    result = update_ini_setting(source_lines, 'tox', 'env_list', 'py36,\npy37',
                                 filename='tox.ini')
     assert "".join(result) == textwrap.dedent("""\
         [tox]
-        envlist =
+        env_list =
             py36,
             py37
         usedevelop = true
@@ -70,15 +70,15 @@ def test_update_ini_setting_multiline():
 def test_update_ini_setting_multiline_first_on_same_line():
     source_lines = textwrap.dedent("""\
         [tox]
-        envlist = py26,
+        env_list = py26,
                   py27
         usedevelop = true
     """).splitlines(True)
-    result = update_ini_setting(source_lines, 'tox', 'envlist', 'py36,\npy37',
+    result = update_ini_setting(source_lines, 'tox', 'env_list', 'py36,\npy37',
                                 filename='tox.ini')
     assert "".join(result) == textwrap.dedent("""\
         [tox]
-        envlist = py36,
+        env_list = py36,
                   py37
         usedevelop = true
     """)
@@ -87,18 +87,18 @@ def test_update_ini_setting_multiline_first_on_same_line():
 def test_update_ini_setting_multiline_with_comments():
     source_lines = textwrap.dedent("""\
         [tox]
-        envlist =
+        env_list =
         # blah blah
         #   py26,py27,pypy
             py26,py27
         # etc.
         usedevelop = true
     """).splitlines(True)
-    result = update_ini_setting(source_lines, 'tox', 'envlist', 'py36,py37',
+    result = update_ini_setting(source_lines, 'tox', 'env_list', 'py36,py37',
                                 filename='tox.ini')
     assert "".join(result) == textwrap.dedent("""\
         [tox]
-        envlist =
+        env_list =
         # blah blah
         #   py26,py27,pypy
             py36,py37
@@ -111,7 +111,7 @@ def test_update_ini_setting_no_section(capsys):
     source_lines = textwrap.dedent("""\
         [toxx]
     """).splitlines(True)
-    result = update_ini_setting(source_lines, 'tox', 'envlist', 'py36,py37',
+    result = update_ini_setting(source_lines, 'tox', 'env_list', 'py36,py37',
                                 filename='tox.ini')
     assert "".join(result) == textwrap.dedent("""\
         [toxx]
@@ -127,13 +127,13 @@ def test_update_ini_setting_no_key(capsys):
         [tox]
         usedevelop = true
     """).splitlines(True)
-    result = update_ini_setting(source_lines, 'tox', 'envlist', 'py36,py37',
+    result = update_ini_setting(source_lines, 'tox', 'env_list', 'py36,py37',
                                 filename='tox.ini')
     assert "".join(result) == textwrap.dedent("""\
         [tox]
         usedevelop = true
     """)
     assert (
-        "Did not find envlist= in [tox] in tox.ini"
+        "Did not find env_list= in [tox] in tox.ini"
         in capsys.readouterr().err
     )

--- a/tests/sources/test_tox.py
+++ b/tests/sources/test_tox.py
@@ -23,7 +23,7 @@ def test_get_tox_ini_python_versions(tmp_path):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27,py36,py27-docs,pylint,py310
+        env_list = py27,py36,py27-docs,pylint,py310
     """))
     assert get_tox_ini_python_versions(tox_ini) == v(['2.7', '3.6', '3.10'])
 
@@ -97,26 +97,26 @@ def test_tox_env_to_py_version(s, expected):
 def test_update_tox_ini_python_versions():
     fp = StringIO(textwrap.dedent("""\
         [tox]
-        envlist = py26, py27
+        env_list = py26, py27
     """))
     fp.name = 'tox.ini'
     result = update_tox_ini_python_versions(fp, v(['3.6', '3.7', '3.10']))
     assert "".join(result) == textwrap.dedent("""\
         [tox]
-        envlist = py36, py37, py310
+        env_list = py36, py37, py310
     """)
 
 
 def test_update_tox_ini_python_syntax_error(capsys):
     fp = StringIO(textwrap.dedent("""\
         [tox
-        envlist = py26, py27
+        env_list = py26, py27
     """))
     fp.name = 'tox.ini'
     result = update_tox_ini_python_versions(fp, v(['3.6', '3.7']))
     assert "".join(result) == textwrap.dedent("""\
         [tox
-        envlist = py26, py27
+        env_list = py26, py27
     """)
     assert (
         "Could not parse tox.ini:"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,7 +148,7 @@ def test_check_mismatch(tmp_path, capsys):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27
+        env_list = py27
     """))
     assert cpv.check_versions(tmp_path) is False
     assert capsys.readouterr().out == textwrap.dedent("""\
@@ -170,7 +170,7 @@ def test_check_poetry_mismatch(tmp_path, capsys):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27
+        env_list = py27
     """))
     assert cpv.check_versions(tmp_path) is False
     assert capsys.readouterr().out == textwrap.dedent("""\
@@ -195,7 +195,7 @@ def test_check_setuptools_mismatch(tmp_path, capsys):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27
+        env_list = py27
     """))
     assert cpv.check_versions(tmp_path) is False
     assert capsys.readouterr().out == textwrap.dedent("""\
@@ -220,7 +220,7 @@ def test_check_flit_mismatch(tmp_path, capsys):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27
+        env_list = py27
     """))
     assert cpv.check_versions(tmp_path) is False
     assert capsys.readouterr().out == textwrap.dedent("""\
@@ -245,7 +245,7 @@ def test_check_mismatch_pypy(tmp_path, capsys):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27, py36, pypy
+        env_list= py27, py36, pypy
     """))
     assert cpv.check_versions(tmp_path) is False
     assert capsys.readouterr().out == textwrap.dedent("""\
@@ -289,7 +289,7 @@ def test_check_only(tmp_path, capsys):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27
+        env_list = py27
     """))
     assert cpv.check_versions(tmp_path, only={'tox.ini'})
     assert capsys.readouterr().out == textwrap.dedent("""\
@@ -310,7 +310,7 @@ def test_poetry_check_only(tmp_path, capsys):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27
+        env_list = py27
     """))
     assert cpv.check_versions(tmp_path, only={'tox.ini'})
     assert capsys.readouterr().out == textwrap.dedent("""\
@@ -334,7 +334,7 @@ def test_setuptools_check_only(tmp_path, capsys):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27
+        env_list = py27
     """))
     assert cpv.check_versions(tmp_path, only={'tox.ini'})
     assert capsys.readouterr().out == textwrap.dedent("""\
@@ -358,7 +358,7 @@ def test_flit_check_only(tmp_path, capsys):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27
+        env_list = py27
     """))
     assert cpv.check_versions(tmp_path, only={'tox.ini'})
     assert capsys.readouterr().out == textwrap.dedent("""\
@@ -627,7 +627,7 @@ def test_update_versions_only(tmp_path):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27
+        env_list = py27
     """))
     replacements = cpv.update_versions(
         tmp_path, add=v(['3.6']), only='tox.ini', dry_run=True,
@@ -775,7 +775,7 @@ def test_main_only(monkeypatch, capsys, tmp_path):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
         [tox]
-        envlist = py27,py36
+        env_list = py27,py36
     """))
     travis_yml = tmp_path / ".travis.yml"
     travis_yml.write_text(textwrap.dedent("""\

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,pypy3,flake8,mypy,isort,coverage
+env_list = py37,py38,py39,py310,py311,pypy3,flake8,mypy,isort,coverage
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Fixes #42 

This is a hard move from `envlist` to `env_list`. Would you prefer a soft migration with both versions supported over a release or two?