### PR TITLE
tox also accepts the env_list spelling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 0.21.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Support the ``env_list`` spelling in tox.ini  `GH #42
+  <https://github.com/mgedmin/check-python-versions/issues/42>`_
 
 
 0.21.2 (2023-02-14)
@@ -12,7 +13,7 @@ Changelog
 
 - Ignore pyproject.toml that has no static metadata instead of
   causing a mismatch error.  `GH #41
-  <https://github.com/mgedmin/check-python-versions/issues/#41>`_.
+  <https://github.com/mgedmin/check-python-versions/issues/41>`_.
 
 - Make sure all the error messages about parsing issues mention the name of the
   file that contains the error.
@@ -68,14 +69,14 @@ Changelog
 
 - Don't drop all PyPy builds when adding/dropping supported versions to GitHub
   Actions files that use a build matrix based on ``python-version``.  `GH #29
-  <https://github.com/mgedmin/check-python-versions/issues/#29>`_
+  <https://github.com/mgedmin/check-python-versions/issues/29>`_
 
 
 0.18.1 (2021-07-02)
 -------------------
 
 - Treat versions like ``3.10.0-beta.3`` as prerelease versions.  `GH #28
-  <https://github.com/mgedmin/check-python-versions/issues/#28>`_.
+  <https://github.com/mgedmin/check-python-versions/issues/28>`_.
 
 
 0.18.0 (2021-01-28)
@@ -85,7 +86,7 @@ Changelog
   support, you need to also run tests on PyPy in your primary CI systems (tox,
   GitHub Actions, Travis CI), and vice versa.  Secondary CI systems (Appveyor,
   manylinux.sh) are excluded from this check.  `GH #26
-  <https://github.com/mgedmin/check-python-versions/issues/#26>`_.
+  <https://github.com/mgedmin/check-python-versions/issues/26>`_.
 
 
 0.17.1 (2020-12-18)
@@ -196,11 +197,11 @@ Changelog
   - preserve multiline ``python_requires=', '.join([...])`` expressions
     (`GH #10 <https://github.com/mgedmin/check-python-versions/issues/10>`_)
   - preserve generative envlists (``envlist = py{27,36}``) in tox.ini
-    (`GH #13 <https://github.com/mgedmin/check-python-versions/issues/#13>`_)
+    (`GH #13 <https://github.com/mgedmin/check-python-versions/issues/13>`_)
   - accept ``envlist=...`` with no spaces around the ``=`` in tox.ini
   - preserve newline-separated envlists with no commas in tox.ini
   - drop PyPy when dropping all supported Python 2.x versions
-    (`GH #11 <https://github.com/mgedmin/check-python-versions/issues/ #11>`_)
+    (`GH #11 <https://github.com/mgedmin/check-python-versions/issues/11>`_)
 
 
 0.13.2 (2020-05-04)

--- a/src/check_python_versions/sources/tox.py
+++ b/src/check_python_versions/sources/tox.py
@@ -35,7 +35,10 @@ def get_tox_ini_python_versions(
     try:
         with open_file(filename) as fp:
             conf.read_file(fp)
-        envlist = conf.get('tox', 'envlist')
+        if conf.has_option('tox', 'env_list'):
+            envlist = conf.get('tox', 'env_list')
+        else:
+            envlist = conf.get('tox', 'envlist')
     except configparser.Error:
         return []
     return sorted({
@@ -124,7 +127,11 @@ def update_tox_ini_python_versions(
         conf = configparser.ConfigParser()
         try:
             conf.read_file(fp)
-            envlist = conf.get('tox', 'envlist')
+            if conf.has_option('tox', 'env_list'):
+                conf_name = 'env_list'
+            else:
+                conf_name = 'envlist'
+            envlist = conf.get('tox', conf_name)
         except configparser.Error as error:
             warn(f"Could not parse {fp.name}: {error}")
             return orig_lines
@@ -132,7 +139,7 @@ def update_tox_ini_python_versions(
     new_envlist = update_tox_envlist(envlist, new_versions)
 
     new_lines = update_ini_setting(
-        orig_lines, 'tox', 'envlist', new_envlist, filename=fp.name,
+        orig_lines, 'tox', conf_name, new_envlist, filename=fp.name,
     )
     return new_lines
 

--- a/tests/sources/test_tox.py
+++ b/tests/sources/test_tox.py
@@ -28,6 +28,15 @@ def test_get_tox_ini_python_versions(tmp_path):
     assert get_tox_ini_python_versions(tox_ini) == v(['2.7', '3.6', '3.10'])
 
 
+def test_get_tox_ini_python_versions_new_spelling(tmp_path):
+    tox_ini = tmp_path / "tox.ini"
+    tox_ini.write_text(textwrap.dedent("""\
+        [tox]
+        env_list = py27,py36,py27-docs,pylint,py310
+    """))
+    assert get_tox_ini_python_versions(tox_ini) == v(['2.7', '3.6', '3.10'])
+
+
 def test_get_tox_ini_python_versions_syntax_error(tmp_path):
     tox_ini = tmp_path / "tox.ini"
     tox_ini.write_text(textwrap.dedent("""\
@@ -104,6 +113,19 @@ def test_update_tox_ini_python_versions():
     assert "".join(result) == textwrap.dedent("""\
         [tox]
         envlist = py36, py37, py310
+    """)
+
+
+def test_update_tox_ini_python_versions_new_spelling():
+    fp = StringIO(textwrap.dedent("""\
+        [tox]
+        env_list = py26, py27
+    """))
+    fp.name = 'tox.ini'
+    result = update_tox_ini_python_versions(fp, v(['3.6', '3.7', '3.10']))
+    assert "".join(result) == textwrap.dedent("""\
+        [tox]
+        env_list = py36, py37, py310
     """)
 
 


### PR DESCRIPTION
Actually this is apparently the preferred spelling, with envlist kept only for backwards compatibility.

Closes #42.

Supersedes #43.