### PR TITLE
Remove unneeded 3.6 mention in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,6 @@ you if they don't match ::
 Installation
 ------------
 
-You need Python 3.6 or newer (f-strings!) to run check-python-versions.
 Install it with ::
 
     python3 -m pip install check-python-versions


### PR DESCRIPTION
Now that this package is 3.10+, and everyone is used to f-strings, you no longer need the 3.6 mention.